### PR TITLE
Don't translate lines with only whitespace to zero

### DIFF
--- a/compiler/compiler.c
+++ b/compiler/compiler.c
@@ -263,7 +263,7 @@ struct command commandList[NUMBER_OF_COMMANDS] = {
             .pattern = "",
             .usedParameters = 0,
             .analysisFunction = NULL,
-            .translationPattern = "0"
+            .translationPattern = ""
         }
 };
 


### PR DESCRIPTION
When a line of a `.memeasm` file contained only whitespace, the compiler would translate it to `0`. Not sure if that is intentional or if this change breaks any previous intended behavior.

Before:
```
$ memeasm -o main to_binary.memeasm
tmp.S: Assembler messages:
tmp.S:18: Error: junk at end of line, first unrecognized character is `0'
tmp.S:22: Error: junk at end of line, first unrecognized character is `0'
tmp.S:23: Error: junk at end of line, first unrecognized character is `0'
tmp.S:25: Error: junk at end of line, first unrecognized character is `0'
tmp.S:30: Error: junk at end of line, first unrecognized character is `0'
tmp.S:32: Error: junk at end of line, first unrecognized character is `0'
tmp.S:35: Error: junk at end of line, first unrecognized character is `0'
tmp.S:38: Error: junk at end of line, first unrecognized character is `0'
tmp.S:39: Error: junk at end of line, first unrecognized character is `0'
```

After:

```
$ memeasm -o main to_binary.memeasm
```

