### PR TITLE
Fix some buffer overruns

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,8 +5,12 @@
 ## Other contributors
 - [xarantolus](https://github.com/xarantolus)
   - Implementation of the "what can I say except [...]" command in v0.1
-  - Suggesting the idea of Monke Jump Markers
+  - Suggested the idea of Monke Jump Markers
   - Bug reporting
+- [aengelke](https://github.com/aengelke)
+  - Fixed some buffer overruns 
+  - Adapted the compilation to no longer use temporary files
+  - Implementation of toupper_str in MemeASM
 - [RobinMarchart](https://github.com/RobinMarchart)
   - Implementation of the "it's a trap" command
 

--- a/compiler/compiler.c
+++ b/compiler/compiler.c
@@ -335,15 +335,21 @@ struct commandsArray compile(FILE *srcPTR) {
  * Attempts to convert the source file to an x86 Assembly file
  * @param srcPTR a pointer to the source file to be compiled
  * @param destPTR a pointer to the destination file.
- * @return 0 on success, 1 otherwise
  */
 int createAssemblyFile(FILE *srcPTR, FILE *destPTR) {
     struct commandsArray commands = compile(srcPTR);
     if(compilationErrors == 0) {
         writeToFile(&commands, destPTR);
-        return 0;
     }
-    return 1;
+
+    fclose(destPTR);
+    freeCommandsArray(&commands);
+
+    if(compilationErrors == 0) {
+        exit(EXIT_SUCCESS);
+    } else {
+        exit(EXIT_FAILURE);
+    }
 }
 
 /**
@@ -366,6 +372,7 @@ void createObjectFile(FILE *srcPTR, char *destFile) {
         gccres = pclose(gccPTR);
     }
 
+    freeCommandsArray(&commands);
     if(compilationErrors != 0 || gccres != 0) {
         exit(EXIT_FAILURE);
     } else {
@@ -393,6 +400,7 @@ void createExecutable(FILE *srcPTR, char *destFile) {
         gccres = pclose(gccPTR);
     }
 
+    freeCommandsArray(&commands);
     if(compilationErrors != 0 || gccres != 0) {
         exit(EXIT_FAILURE);
     } else {

--- a/compiler/compiler.c
+++ b/compiler/compiler.c
@@ -17,6 +17,7 @@ You should have received a copy of the GNU General Public License
 along with MemeAssembly. If not, see <https://www.gnu.org/licenses/>.
 */
 
+#include "compiler.h"
 #include <stdio.h>  //Printf() function
 #include <stdlib.h> //Exit() function
 

--- a/compiler/compiler.c
+++ b/compiler/compiler.c
@@ -344,28 +344,20 @@ int compile(FILE *srcPTR, FILE *destPTR) {
  * @param destFile the name of the destination file
  */
 void createObjectFile(FILE *srcPTR, char *destFile) {
-    FILE *tmpPTR = fopen("tmp.S","w");
-    int result = compile(srcPTR, tmpPTR);
+    const char* commandPrefix = "gcc -O -c -x assembler - -o";
+    char command[strlen(commandPrefix) + strlen(destFile) + 1];
+    strcpy(command, commandPrefix);
+    strcat(command, destFile);
 
-    if(result == 0) {
-        printStatusMessage("Calling gcc");
-        system("gcc -O -c tmp.S");
+    // Pipe assembler code directly to GCC via stdin
+    FILE* gccPTR = popen(command, "w");
+    int result = compile(srcPTR, gccPTR);
+    int gccres = pclose(gccPTR);
 
-        //The file will now be called tmp.o, we hence have to rename it
-        char commandPrefix[] = "mv tmp.o ";
-        size_t strLen = strlen(commandPrefix) + strlen(destFile);
-        char command[strLen];
-        command[0] = '\0';
-
-        strncat(command, commandPrefix, strLen);
-        strncat(command, destFile, strLen);
-        system(command);
-
-        printDebugMessage("Removing temporary file", "");
-        system("rm tmp.S");
-        exit(EXIT_SUCCESS);
-    } else {
+    if(result != 0 || gccres != 0) {
         exit(EXIT_FAILURE);
+    } else {
+        exit(EXIT_SUCCESS);
     }
 }
 
@@ -375,24 +367,19 @@ void createObjectFile(FILE *srcPTR, char *destFile) {
  * @param destFile the name of the destination file
  */
 void createExecutable(FILE *srcPTR, char *destFile) {
-    FILE *tmpPTR = fopen("tmp.S","w");
-    int result = compile(srcPTR, tmpPTR);
+    const char* commandPrefix = "gcc -O -no-pie -x assembler - -o";
+    char command[strlen(commandPrefix) + strlen(destFile) + 1];
+    strcpy(command, commandPrefix);
+    strcat(command, destFile);
 
-    if(result == 0) {
-        printStatusMessage("Calling gcc");
-        char commandPrefix[] = "gcc -no-pie tmp.S -o ";
-        size_t strLen = strlen(commandPrefix) + strlen(destFile);
-        char command[strLen];
-        command[0] = '\0';
+    // Pipe assembler code directly to GCC via stdin
+    FILE* gccPTR = popen(command, "w");
+    int result = compile(srcPTR, gccPTR);
+    int gccres = pclose(gccPTR);
 
-        strncat(command, commandPrefix, strLen);
-        strncat(command, destFile, strLen);
-        system(command);
-
-        printDebugMessage("Removing temporary file", "");
-        system("rm tmp.S");
-        exit(EXIT_SUCCESS);
-    } else {
+    if(result != 0 || gccres != 0) {
         exit(EXIT_FAILURE);
+    } else {
+        exit(EXIT_SUCCESS);
     }
 }

--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -26,6 +26,4 @@ void createExecutable(FILE *srcPTR, char *destFile);
 void createObjectFile(FILE *srcPTR, char *destFile);
 int createAssemblyFile(FILE *srcPTR, FILE *destPTR);
 
-void freeCommandsArray(struct commandsArray *commands);
-
 #endif

--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -20,13 +20,12 @@ along with MemeAssembly. If not, see <https://www.gnu.org/licenses/>.
 #ifndef COMPILER_H
 #define COMPILER_H
 
-#include <stdio.h>  //Printf() function
-#include <stdlib.h> //Exit() function
-
-#include <string.h> //String functions
+#include "commands.h"
 
 void createExecutable(FILE *srcPTR, char *destFile);
 void createObjectFile(FILE *srcPTR, char *destFile);
 int createAssemblyFile(FILE *srcPTR, FILE *destPTR);
+
+void freeCommandsArray(struct commandsArray *commands);
 
 #endif

--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -24,8 +24,8 @@ along with MemeAssembly. If not, see <https://www.gnu.org/licenses/>.
 
 #include "commands.h"
 
-void createExecutable(FILE *srcPTR, char *destFile);
-void createObjectFile(FILE *srcPTR, char *destFile);
-int createAssemblyFile(FILE *srcPTR, FILE *destPTR);
+_Noreturn void createExecutable(FILE *srcPTR, char *destFile);
+_Noreturn void createObjectFile(FILE *srcPTR, char *destFile);
+_Noreturn int createAssemblyFile(FILE *srcPTR, FILE *destPTR);
 
 #endif

--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -27,6 +27,6 @@ along with MemeAssembly. If not, see <https://www.gnu.org/licenses/>.
 
 void createExecutable(FILE *srcPTR, char *destFile);
 void createObjectFile(FILE *srcPTR, char *destFile);
-int compile(FILE *srcPTR, FILE *destPTR);
+int createAssemblyFile(FILE *srcPTR, FILE *destPTR);
 
 #endif

--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -20,6 +20,8 @@ along with MemeAssembly. If not, see <https://www.gnu.org/licenses/>.
 #ifndef COMPILER_H
 #define COMPILER_H
 
+#include <stdio.h>
+
 #include "commands.h"
 
 void createExecutable(FILE *srcPTR, char *destFile);

--- a/compiler/memeasm.c
+++ b/compiler/memeasm.c
@@ -164,7 +164,9 @@ int main(int argc, char* argv[]) {
             }
 
 
-            return compile(inputFile, outputFile);
+            int res = compile(inputFile, outputFile);
+            fclose(outputFile);
+            return res;
         }
     }
 }

--- a/compiler/memeasm.c
+++ b/compiler/memeasm.c
@@ -1,7 +1,7 @@
 /*
 This file is part of the MemeAssembly compiler.
 
- Copyright © 2021 Tobias Kamm
+ Copyright © 2021 Tobias Kamm and contributors
 
 MemeAssembly is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/compiler/memeasm.c
+++ b/compiler/memeasm.c
@@ -126,7 +126,7 @@ int main(int argc, char* argv[]) {
             return 1;
         }
 
-        //Create a stat struct to check if the file is a regular file. If we did not check for this, an argument like "-o /dev/urandom" would pass without errors
+        //Create a stat struct to check if the file is a regular file. If we did not check for this, an input file like "/dev/urandom" would pass without errors
         struct stat inputFileStat;
         fstat(fileno(inputFile), &inputFileStat);
         if (!S_ISREG(inputFileStat.st_mode)) {
@@ -164,7 +164,7 @@ int main(int argc, char* argv[]) {
             }
 
 
-            int res = compile(inputFile, outputFile);
+            int res = createAssemblyFile(inputFile, outputFile);
             fclose(outputFile);
             return res;
         }

--- a/compiler/memeasm.c
+++ b/compiler/memeasm.c
@@ -164,9 +164,7 @@ int main(int argc, char* argv[]) {
             }
 
 
-            int res = createAssemblyFile(inputFile, outputFile);
-            fclose(outputFile);
-            return res;
+            createAssemblyFile(inputFile, outputFile);
         }
     }
 }

--- a/compiler/parser/parser.c
+++ b/compiler/parser/parser.c
@@ -106,7 +106,7 @@ struct parsedCommand parseLine(int lineNum) {
 
     //Temporarily save the line on the stack to be able to restore when a comparison failed
     char lineCpy[strlen(line) + 1];
-    strncpy(lineCpy, line, strlen(line) + 1);
+    strcpy(lineCpy, line);
 
     //Define save pointers for strtok_r
     char *savePtrLine;
@@ -114,7 +114,7 @@ struct parsedCommand parseLine(int lineNum) {
 
     //Iterate through all possible commands
     for(int i = 0; i < NUMBER_OF_COMMANDS - 2; i++) {
-        strncpy(lineCpy, line, strlen(line) + 1);
+        strcpy(lineCpy, line);
         savePtrLine = NULL;
         savePtrPattern = NULL;
 

--- a/compiler/translator/translator.c
+++ b/compiler/translator/translator.c
@@ -173,18 +173,18 @@ void translateToAssembly(struct commandsArray *commandsArray, size_t index, FILE
                 translatedLine[currentStrLen] = '[';
                 translatedLine[currentStrLen + 1] = '\0';
                 //Append the parameter
-                strncat(translatedLine, parameter, strLen);
+                strcat(translatedLine, parameter);
                 //Append a ']'
                 currentStrLen = strlen(translatedLine);
                 translatedLine[currentStrLen] = ']';
                 translatedLine[currentStrLen + 1] = '\0';
             } else {
                 printDebugMessage("\tAppending parameter", parameter);
-                strncat(translatedLine, parameter, strLen);
+                strcat(translatedLine, parameter);
             }
         } else {
             char appendix[2] = {character, '\0'};
-            strncat(translatedLine, appendix, strLen);
+            strcat(translatedLine, appendix);
         }
     }
 

--- a/compiler/translator/translator.c
+++ b/compiler/translator/translator.c
@@ -19,7 +19,6 @@ along with MemeAssembly. If not, see <https://www.gnu.org/licenses/>.
 
 #include "translator.h"
 #include "../logger/log.h"
-#include "../compiler.h"
 
 #include <time.h>
 #include <string.h>
@@ -284,7 +283,4 @@ void writeToFile(struct commandsArray *commandsArray, FILE *outputFile) {
     if(optimisationLevel == -4) {
         fprintf(outputFile, ".align 536870912\n");
     }
-
-    printDebugMessage("Done, freeing commandsArray struct", "");
-    freeCommandsArray(commandsArray);
 }

--- a/compiler/translator/translator.c
+++ b/compiler/translator/translator.c
@@ -1,7 +1,7 @@
 /*
 This file is part of the MemeAssembly compiler.
 
- Copyright © 2021 Tobias Kamm
+ Copyright © 2021 Tobias Kamm and contributors
 
 MemeAssembly is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/compiler/translator/translator.c
+++ b/compiler/translator/translator.c
@@ -138,9 +138,17 @@ void translateToAssembly(struct commandsArray *commandsArray, size_t index, FILE
     struct command command = commandList[parsedCommand.opcode];
     char *translationPattern = command.translationPattern;
 
-    size_t strLen = strlen(translationPattern);
-    for(int i = 0; i < command.usedParameters; i++) {
-        strLen += strlen(parsedCommand.parameters[i]);
+    size_t patternLen = strlen(translationPattern);
+    size_t strLen = patternLen;
+    for(size_t i = 0; i < patternLen; i++) {
+        char character = translationPattern[i];
+        if(character >= '0' && character <= (char) command.usedParameters + 47) {
+            char *parameter = parsedCommand.parameters[character - 48];
+            strLen += strlen(parameter);
+            if(parsedCommand.isPointer == (character - 48) + 1) {
+                strLen += 2; // for [ and ]
+            }
+        }
     }
 
     char *translatedLine = malloc(strLen + 3); //Include an extra byte for the null-Pointer and two extra bytes in case []-brackets are needed for a pointer
@@ -150,7 +158,7 @@ void translateToAssembly(struct commandsArray *commandsArray, size_t index, FILE
     }
     translatedLine[0] = '\0';
 
-    for(size_t i = 0; i < strlen(translationPattern); i++) {
+    for(size_t i = 0; i < patternLen; i++) {
         char character = translationPattern[i];
         if(character >= '0' && character <= (char) command.usedParameters + 47) {
             char *parameter = parsedCommand.parameters[character - 48];

--- a/compiler/translator/translator.c
+++ b/compiler/translator/translator.c
@@ -283,7 +283,4 @@ void writeToFile(struct commandsArray *commandsArray, FILE *outputFile) {
     if(optimisationLevel == -4) {
         fprintf(outputFile, ".align 536870912\n");
     }
-
-    printDebugMessage("Done, closing output file", "");
-    fclose(outputFile);
 }

--- a/compiler/translator/translator.c
+++ b/compiler/translator/translator.c
@@ -19,6 +19,7 @@ along with MemeAssembly. If not, see <https://www.gnu.org/licenses/>.
 
 #include "translator.h"
 #include "../logger/log.h"
+#include "../compiler.h"
 
 #include <time.h>
 #include <string.h>
@@ -283,4 +284,7 @@ void writeToFile(struct commandsArray *commandsArray, FILE *outputFile) {
     if(optimisationLevel == -4) {
         fprintf(outputFile, ".align 536870912\n");
     }
+
+    printDebugMessage("Done, freeing commandsArray struct", "");
+    freeCommandsArray(commandsArray);
 }


### PR DESCRIPTION
I found these bugs while learning MemeASM. I also changed the compilation to no longer use tmp files and instead pipe the assembler code directly into GCC via stdin -- not too happy with the current approach, though, as GCC will now be called even if compilation fails.

Also, feel free to cherry-pick individual commits. :)