### PR TITLE
Set correct file descriptor for writechar output

### DIFF
--- a/compiler/translator/translator.c
+++ b/compiler/translator/translator.c
@@ -382,6 +382,7 @@ void writeToFile(struct compileState* compileState, FILE *outputFile) {
                             "push rdx\n\t"
                             "mov rdx, 1\n\t"
                             "lea rsi, [rip + .LCharacter]\n\t"
+                            "mov rdi, 1\n\t"
                             #ifdef LINUX
                             "mov rax, 1\n\t"
  			                #else


### PR DESCRIPTION
Fixes kammt/MemeAssembly#72