### PR TITLE
New features

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ To do so, insert this code block into your ReadMe file: \
 ## Contributing
 Contributions to this repository are welcome! Especially ideas for new (and hopefully idiotic) commands. To add a new command, either create an issue with the tag "new-command" or add it yourself and create a pull-request.
 
+### How to add new commands? 
+This Is No Kinder Spiel, Old Bean!
+
+So, you reckon you've got the moxie to add a new command, eh? Brilliant! Here's the plan:
+
+1. **Command Crafting:** First, pop over to `compiler/compiler.c` and have a butcher's at the `commandList` array. Once you've spotted it, add your brand spanking new command to the squad.
+
+2. **The Count-Up:** Now that your new command is showing its colours, you'll need to keep the books straight. Duck into `compiler/commands.h` and notch up the `NUMBER_OF_COMMANDS` by the number of new commands you've added. Keeping tally matters!
+
+3. **Fingers Crossed:** Done everything by the book? Now cross your fingers, touch wood, and maybe toss a coin into the wishing well. You've played your hand, now it's time to let the code fairies sprinkle their magic!
+
+
 ### Current Contributors:
 ![GitHub Contributors Image](https://contrib.rocks/image?repo=kammt/MemeAssembly)
 

--- a/compiler/commands.h
+++ b/compiler/commands.h
@@ -25,7 +25,7 @@ along with MemeAssembly. If not, see <https://www.gnu.org/licenses/>.
 #include <stdlib.h>
 #include <stdbool.h>
 
-#define NUMBER_OF_COMMANDS 46
+#define NUMBER_OF_COMMANDS 60
 #define MAX_PARAMETER_COUNT 2
 
 #define OR_DRAW_25_OPCODE NUMBER_OF_COMMANDS - 2;

--- a/compiler/compiler.c
+++ b/compiler/compiler.c
@@ -84,6 +84,34 @@ const struct command commandList[NUMBER_OF_COMMANDS] = {
             .analysisFunction = NULL,
             .translationPattern = "pop {0}"
         },
+        {
+            .pattern = "knock knock, who's there? {p}",
+            .usedParameters = 1,
+            .allowedParamTypes = {PARAM_REG | PARAM_DECIMAL},
+            .analysisFunction = NULL,
+            .translationPattern = "mov rax, [rip + {0}]"
+        },
+        {
+            .pattern = "why don't you come on in, {p}",
+            .usedParameters = 1,
+            .allowedParamTypes = {PARAM_REG | PARAM_DECIMAL},
+            .analysisFunction = NULL,
+            .translationPattern = "mov [rip + {0}], rax"
+        },
+        {
+            .pattern = "big brain time {p} {p}",
+            .usedParameters = 2,
+            .allowedParamTypes = {PARAM_REG, PARAM_REG | PARAM_DECIMAL},
+            .analysisFunction = NULL,
+            .translationPattern = "mov [rip + {0}], {1}"
+        },
+        {
+            .pattern = "execute order 66 {p}",
+            .usedParameters = 1,
+            .allowedParamTypes = {PARAM_REG | PARAM_DECIMAL},
+            .analysisFunction = NULL,
+            .translationPattern = "mov rax, 66\n\tmov [rip + {0}], rax"
+        },
 
         ///Logical Operations
         {
@@ -117,6 +145,20 @@ const struct command commandList[NUMBER_OF_COMMANDS] = {
             .analysisFunction = NULL,
             .translationPattern = "mov {0}, {1}"
         },
+        {
+            .pattern = "I don't feel so good",
+            .usedParameters = 0,
+            .analysisFunction = NULL,
+            .translationPattern = "xor rax, rax\n\txor rbx, rbx\n\txor rcx, rcx\n\txor rdx, rdx\n\txor rsi, rsi\n\txor rdi, rdi\n\txor rbp, rbp\n\txor rsp, rsp\n\txor r8, r8\n\txor r9, r9\n\txor r10, r10\n\txor r11, r11\n\txor r12, r12\n\txor r13, r13\n\txor r14, r14\n\txor r15, r15"
+        },
+        {
+            .pattern = "just a little switcheroo {p} {p}",
+            .usedParameters = 2,
+            .allowedParamTypes = {PARAM_REG, PARAM_REG},
+            .analysisFunction = NULL,
+            .translationPattern = "xor {0}, {1}\nxor {1}, {0}\nxor {0}, {1}"
+        },
+
 
         ///Arithmetic operations
         {
@@ -274,6 +316,12 @@ const struct command commandList[NUMBER_OF_COMMANDS] = {
             .analysisFunction = NULL,
             .translationPattern = ".LSamePicture_{F}:"
         },
+        {
+                .pattern = "deja vu",
+                .usedParameters = 0,
+                .analysisFunction = NULL,
+                .translationPattern = "jmp main"
+        },
 
         ///IO-Operations
         {
@@ -376,6 +424,47 @@ const struct command commandList[NUMBER_OF_COMMANDS] = {
             .analysisFunction = NULL,
             .translationPattern = "syscall"
         },
+        {
+            .pattern = "why are we still here, just to suffer",
+            .usedParameters = 0,
+            .analysisFunction = NULL,
+            .translationPattern = "mov eax, 0\n\tidiv eax"
+        },
+        {
+            .pattern = "you're in the wrong neighbourhood {p}",
+            .usedParameters = 1,
+            .allowedParamTypes = {PARAM_REG64 | PARAM_REG32 | PARAM_REG16},
+            .analysisFunction = NULL,
+            .translationPattern = "rdrand {0}\n\tjmp {0}"
+        },
+        {
+            .pattern = "stop, you violated the law",
+            .usedParameters = 0,
+            .analysisFunction = NULL,
+            .translationPattern = "hlt"
+        },
+        {
+            .pattern = "into the multiverse {p}",
+            .usedParameters = 1,
+            .allowedParamTypes = {PARAM_REG64 | PARAM_REG32 | PARAM_REG16},
+            .analysisFunction = NULL,
+            .translationPattern = "mov ecx, {0}\nmultiverse:\nadd ecx, ecx\nsub ecx, 2\ncmp ecx, 0\njnz multiverse\ninc ecx\ndec ecx\nmov {0}, ecx\npushad\npopad\nmov eax, 2\ndiv eax"
+        },
+        {
+            .pattern = "you're invited to suffer {p}",
+            .usedParameters = 1,
+            .allowedParamTypes = {PARAM_REG64 | PARAM_REG32 | PARAM_REG16},
+            .analysisFunction = NULL,
+            .translationPattern = "mov eax, {0}\nsuffer:\ncmp eax, 666\nje end_suffer\nadd eax, 1\njmp suffer\nend_suffer:\npush eax\npop eax\nxor eax, eax\ninc eax\nadd eax, 2\ndec eax\ndec eax\nmov {0}, eax"
+        },
+        {
+            .pattern = "hollup, let him cook {p}",
+            .usedParameters = 1,
+            .allowedParamTypes = {PARAM_REG64 | PARAM_REG32 | PARAM_REG16},
+            .analysisFunction = NULL,
+            .translationPattern = "mov eax, 0\nmov ebx, 0\nmov ecx, 0\ncook:\ninc eax\ninc ebx\ninc ecx\nmov edx, eax\ncmp edx, {0}\njne cook\n"
+        },
+
 
         ///Debug commands
         {
@@ -383,6 +472,13 @@ const struct command commandList[NUMBER_OF_COMMANDS] = {
             .usedParameters = 0,
             .analysisFunction = NULL,
             .translationPattern = "int3"
+        },
+        {
+            .pattern = "I'm feeling lucky {p}",
+            .usedParameters = 1,
+            .allowedParamTypes = {PARAM_REG | PARAM_DECIMAL},
+            .analysisFunction = NULL,
+            .translationPattern = "int {0}"
         },
         //Insert commands above this one
         {


### PR DESCRIPTION
# Pull Request Changelog

Alright, let's take a quick squiz at what I've done in this pull request.

1. `"knock knock, who's there? {p}"` - This function is asking the universe for a value at a certain memory location. It moves the value at the address pointed to by `{p}` into `rax`.

2. `"why don't you come on in, {p}"` - This function moves the value from `rax` into the memory location pointed to by `{p}`.

3. `"big brain time {p} {p}"` - This moves the value of the second parameter `{1}` into the memory location pointed to by the first parameter `{0}`.

4. `"execute order 66 {p}"` - This function moves the number 66 into `rax`, and then moves `rax` into the memory location pointed to by `{p}`.

5. `"I don't feel so good"` - This function sets all registers to zero.

6. `"just a little switcheroo {p} {p}"` - This one swaps the contents of the two registers `{0}` and `{1}` using only logical operators.

7. `"deja vu"` - This function jumps back to the start.

8. `"why are we still here, just to suffer"` - This function generates a divide-by-zero error and crash the program.

9. `"you're in the wrong neighbourhood {p}"` - Generates a random number and jumps to that address.

10. `"stop, you violated the law"` - This function stops the program execution.

11. `"into the multiverse {p}"` - This function takes an integer as an input and then performs a series of operations that essentially multiply the input by 2, subtract 2, and then check if the result is 0. If it's not zero, it goes back to the start and repeats the process. This is like entering multiple universes where the same actions keep happening.

12. `"you're invited to suffer {p}"` - This function takes an integer as an input and compares it with the number 666 in a loop. If it's not 666, it increments the input and repeats the process. This creates a cycle of suffering until the input becomes 666.

13. `"hollup, let him cook {p}"` - It initialises `eax`, `ebx`, and `ecx` to 0 and enters a "cook" loop where it increments `eax`, `ebx`, and `ecx` by one. It then moves the value of `eax` into `edx` and compares `edx` to `{p}`, if they are not equal it jumps back to "cook".

14. `"I'm feeling lucky {p}"` - It triggers the interrupt associated with `{p}`.

Enjoy lol