### PR TITLE
document memory access

### DIFF
--- a/commands/arithmetic-operations.md
+++ b/commands/arithmetic-operations.md
@@ -49,7 +49,12 @@ Adds/Subtracts 1 from the specified destination register
 Calculates [register] = [register] ^ [value/register]
 
 ## Examples
-#### 1. Shift rax to the right by 6 bits
+#### 1. Add the value at address eax to ebx
+```
+ebx units are ready, with eax do you know de wey more well on the way
+```
+
+#### 2. Shift rax to the right by 6 bits
 ```
 they had us in the first half, not gonna lie rax
 they had us in the first half, not gonna lie rax
@@ -59,7 +64,7 @@ they had us in the first half, not gonna lie rax
 they had us in the first half, not gonna lie rax
 ```
 
-#### 2. Repeatedly print the alphabet by saving and restoring rax
+#### 3. Repeatedly print the alphabet by saving and restoring rax
 ```
 I like to have fun, fun, fun, fun, fun, fun, fun, fun, fun, fun main
     rax is brilliant, but I like 65

--- a/commands/random-commands.md
+++ b/commands/random-commands.md
@@ -1,3 +1,9 @@
+## Memory access / pointers to memory
+### Definition
+```[register] do you know de wey```
+### Description
+Adding the suffix interprets the register not as a value but a pointer to memory.
+
 ## Crashing the program
 ### Definition
 `guess I'll die`

--- a/commands/register-manipulation.md
+++ b/commands/register-manipulation.md
@@ -25,7 +25,12 @@ ecx is brilliant, but I like eax
 edx is brilliant, but I like eax
 ```
 
-#### 3. Intentionally cause a segFault by modifying the Stack Pointer
+#### 3. Move the value at address eax into ebx
+```
+ebx is brilliant, but I like eax do you know de wey
+```
+
+#### 4. Intentionally cause a segFault by modifying the Stack Pointer
 ```
 rsp is brilliant, but I like 69
 ```


### PR DESCRIPTION
Currently memory accesses using `do you know de wey` are only visible in the changelog and not in the actual docs

- Added the actual command section under random-commands because it doesnt really fit in anywhere
- Added simple examples in register-manipulation and arithmetic-operations